### PR TITLE
Make word grid responsive to screen width

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -84,13 +84,15 @@ body{
 
 .grid-panel{display:flex; align-items:center; justify-content:center;}
 .grid{
-  --cell-size: min(7.2vh, 48px);
+  width:100%;
+  max-width:100%;
   display:grid; gap:6px;
-  grid-template-columns: repeat(var(--grid-size), var(--cell-size));
-  grid-template-rows: repeat(var(--grid-size), var(--cell-size));
+  grid-template-columns: repeat(var(--grid-size), 1fr);
   touch-action: manipulation;
 }
 .cell{
+  aspect-ratio:1;
+  width:100%;
   display:flex; align-items:center; justify-content:center;
   background:#ffffff; border:1px solid #e5e7eb; border-radius:.6rem;
   user-select:none; -webkit-user-select:none;


### PR DESCRIPTION
## Summary
- ensure grid container uses responsive fractions so it fits within the screen width
- scale letter boxes via aspect-ratio to shrink as grid size grows

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1343f64548331aeb93cdddce8eee8