### PR TITLE
Clear persisted selections on load

### DIFF
--- a/app.js
+++ b/app.js
@@ -76,6 +76,8 @@
     // load from storage or create new
     const saved = load();
     if (saved){
+      // Drop any persisted letter selections so hidden leftovers don't block matches
+      saved.selected = [];
       state = saved;
       applySettingsToUI();
       renderAll();


### PR DESCRIPTION
## Summary
- Reset saved selection state when loading from storage
- Prevent hidden leftover cells from blocking word matches

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a13efefc048331af26c031a66ce874