### PR TITLE
Add themed word banks and fix grid size

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ A kid-friendly word search game where you tap letters to select/deselect. When y
 - Tap to select/deselect letters; auto-detects correct words from the Word Bank
 - Dynamic Word Bank: found words are replaced with new hidden words
 - Score by word length; progress saves automatically
-- Adjustable grid size, bank size, and difficulty (diagonals/backwards)
+- Fixed 10×10 grid with adjustable bank size and difficulty (diagonals/backwards)
+- Choose from themed word banks: Kid's Words, Harry Potter's World, Star Wars, or Disney Movies
 - Installable PWA with offline support
 
 ## Quick Start
@@ -17,7 +18,7 @@ A kid-friendly word search game where you tap letters to select/deselect. When y
 3. Open `http://localhost:8080` in a browser. Click **Install** to add it to your device.
 
 ## Customize Words
-Edit the `WORD_POOL` in `app.js`. Keep words shorter than or equal to the grid size.
+Edit the lists in `WORD_POOLS` inside `app.js`. Keep words shorter than or equal to the grid size.
 
 ## Notes
 - The selection must exactly match the letters/positions of a word from the active Word Bank.

--- a/index.html
+++ b/index.html
@@ -32,10 +32,6 @@
         <details>
           <summary>Settings</summary>
           <div class="settings">
-            <label>Grid Size
-              <input type="range" id="gridSize" min="8" max="12" value="10">
-              <span id="gridSizeLabel">10 × 10</span>
-            </label>
             <label>Word Bank Size
               <input type="range" id="bankSize" min="4" max="8" value="6">
               <span id="bankSizeLabel">6 words</span>
@@ -54,6 +50,16 @@
 
       <div class="card">
         <h2>Word Bank</h2>
+        <div class="pool-selector">
+          <label for="wordPool">Choose a Word Bank:</label>
+          <select id="wordPool">
+            <option value="kids">Kid's Words</option>
+            <option value="harry">Harry Potter's World</option>
+            <option value="starwars">Star Wars</option>
+            <option value="disney">Disney Movies</option>
+          </select>
+          <button id="playPoolBtn" class="secondary">Play this Word Bank</button>
+        </div>
         <ul id="wordBank" class="word-bank"></ul>
         <div id="winBanner" class="win" hidden>🎉 Great job! You found them all!</div>
       </div>

--- a/styles.css
+++ b/styles.css
@@ -82,6 +82,16 @@ body{
   background:#ecfeff; border:1px solid #a5f3fc; color:#0369a1; font-weight:700;
 }
 
+.pool-selector{
+  display:flex;
+  align-items:center;
+  gap:.5rem;
+  margin-bottom:.5rem;
+}
+.pool-selector select{
+  flex:1;
+}
+
 .grid-panel{display:flex; align-items:center; justify-content:center;}
 .grid{
   width:100%;


### PR DESCRIPTION
## Summary
- Fix grid to 10×10 by removing grid-size option
- Add selectable themed word banks and 'Play this Word Bank' control
- Document new themes and fixed grid in README

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a143ab81e88331838d337972741080