### PR TITLE
Stack Word Bank controls vertically

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -84,12 +84,15 @@ body{
 
 .pool-selector{
   display:flex;
-  align-items:center;
+  flex-direction:column;
   gap:.5rem;
   margin-bottom:.5rem;
 }
 .pool-selector select{
-  flex:1;
+  width:100%;
+}
+.pool-selector button{
+  width:100%;
 }
 
 .grid-panel{display:flex; align-items:center; justify-content:center;}


### PR DESCRIPTION
## Summary
- Stack Word Bank label, selector, and button vertically for better spacing

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a14921db7c8331aea0725dfd8567c1